### PR TITLE
Issue #29: prevent duplicate cards in the Set Builder

### DIFF
--- a/DominionCompanion/models/cards/CardData.swift
+++ b/DominionCompanion/models/cards/CardData.swift
@@ -53,12 +53,14 @@ class CardData: ObservableObject {
     let maxCards: Int
     let maxVictoryTokens: Int
     let maxCoinTokens: Int
-    
+
     var cardsFromChosenExpansions: [Card] {
         get {
             let expansions = Settings.shared.chosenExpansions.count > 0 ? Settings.shared.chosenExpansions : self.allExpansions
             guard expansions.count > 0 else { return kingdomCards.filter { !excludedCards.contains($0) } }
-            let cards = self.kingdomCards.filter { expansions.contains($0.expansion) && !excludedCards.contains($0) }
+            let cards = Utilities.deduplicateByName(cards:
+                self.kingdomCards.filter { expansions.contains($0.expansion) && !excludedCards.contains($0) }
+            )
             return cards
         }
     }

--- a/DominionCompanion/utilities/Utilities.swift
+++ b/DominionCompanion/utilities/Utilities.swift
@@ -22,6 +22,17 @@ class Utilities {
     public static func sortByExpansionAndName(card1: Card, card2: Card) -> Bool {
         return card1.expansion == card2.expansion ? Utilities.alphabeticSort(card1: card1, card2: card2) : (card1.expansion < card2.expansion)
     }
+
+    public static func deduplicateByName(cards: [Card]) -> [Card] {
+        var cardNames = Set<String>()
+        var deduped = Array<Card>()
+        for card in cards {
+            if cardNames.insert(card.name).inserted {
+                deduped.append(card)
+            }
+        }
+        return deduped
+    }
 }
 
 enum SortMode: String, CaseIterable {

--- a/UnitTests/UtilitiesTest.swift
+++ b/UnitTests/UtilitiesTest.swift
@@ -15,6 +15,8 @@ class UtilitiesTest: XCTestCase {
     let card1 = Card(id: "1", cost: 2, debt: 0, potion: false, actions: 1, buys: 0, cards: 1, name: "Cantrip", text: "Example Card", expansion: "Test", types: ["Action"], trash: false, exile: false, tokens: TestData.noTokens, supply: true, related: [])
     let card2 = Card(id: "2", cost: 5, debt: 0, potion: false, actions: 1, buys: 0, cards: 2, name: "Laboratory", text: "Example Card", expansion: "ATest", types: ["Action"], trash: false, exile: false, tokens: TestData.noTokens, supply: true, related: [])
     let card3 = Card(id: "3", cost: 6, debt: 0, potion: false, actions: 0, buys: 0, cards: 0, name: "Gold", text: "Example Card", expansion: "Test", types: ["Treasure"], trash: false, exile: false, tokens: TestData.noTokens, supply: true, related: [])
+    let card4 = Card(id: "2", cost: 5, debt: 0, potion: false, actions: 1, buys: 0, cards: 2, name: "Laboratory", text: "Example Card", expansion: "ATest (1st Edition)", types: ["Action"], trash: false, exile: false, tokens: TestData.noTokens, supply: true, related: [])
+
     
     func testAlphabeticSort() {
         let expected = [card1, card3, card2]
@@ -31,6 +33,13 @@ class UtilitiesTest: XCTestCase {
     func testExpansionSort() {
         let expected = [card2, card1, card3]
         let actual = [card3, card1, card2].sorted(by: SortMode.expansion.sortFunction())
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testDeduplicateByName() {
+        let expected = ["Cantrip", "Gold", "Laboratory"]
+        let actual = Utilities.deduplicateByName(cards: [card1, card2, card3, card4])
+            .map { $0.name }.sorted()
         XCTAssertEqual(expected, actual)
     }
 }

--- a/UnitTests/models/cards/CardDataTests.swift
+++ b/UnitTests/models/cards/CardDataTests.swift
@@ -22,8 +22,12 @@ class CardDataTests: XCTestCase {
 
     func testChoosingExpansions() {
         Settings.shared.chosenExpansions = []
-        XCTAssertEqual(CardData.shared.cardsFromChosenExpansions.count, CardData.shared.kingdomCards.count)
+        XCTAssertEqual(CardData.shared.cardsFromChosenExpansions.count, Set(CardData.shared.kingdomCards.map { $0.name }).count)
+
         Settings.shared.chosenExpansions = ["Base"]
         XCTAssertEqual(CardData.shared.cardsFromChosenExpansions.count, 26)
+
+        Settings.shared.chosenExpansions = ["Intrigue", "Intrigue (1st Edition)"]
+        XCTAssertEqual(CardData.shared.cardsFromChosenExpansions.count, 32)
     }
 }


### PR DESCRIPTION
These changes add a simple method in the Utilities class to deduplicate a list of `Card`s by name, and modifies the `cardsFromChosenExpansions` getter in `CardData` to use that method to deduplicate the result set of cards before returning it.